### PR TITLE
Use X11::X11 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(kImageAnnotator
 target_link_libraries(kImageAnnotator PUBLIC Qt5::Widgets PRIVATE kColorPicker::kColorPicker)
 
 if (UNIX)
-	target_link_libraries(kImageAnnotator PRIVATE X11)
+	target_link_libraries(kImageAnnotator PRIVATE X11::X11)
 endif ()
 
 target_compile_definitions(kImageAnnotator PRIVATE KIMAGEANNOTATOR_LIB)


### PR DESCRIPTION
This fixes the build on FreeBSD, which otherwise would fail with 
`   ld: error: unable to find library -lX11 `
as the path to the library is not added to the linker paths.